### PR TITLE
chore: update API URL for cross-chain transactions

### DIFF
--- a/client/src/hooks/useCrossChainTxn.tsx
+++ b/client/src/hooks/useCrossChainTxn.tsx
@@ -1,7 +1,7 @@
 import type { CrossChainTxn } from "@/mock";
 import { useQuery } from "@tanstack/react-query";
 
-const API_URL = import.meta.env.VITE_BACKEND_URL;
+const API_URL = "https://circles-api.onrender.com/api/cross-chain-txn?address=";
 
 if (!API_URL) {
   throw new Error("VITE_BACKEND_URL is not set");


### PR DESCRIPTION
- Changed the API_URL in useCrossChainTxn hook to a hardcoded endpoint for cross-chain transactions.
- This adjustment is intended for testing purposes and may need to be reverted to an environment variable for production use.